### PR TITLE
Change QCC back to `-std=c++17` and add `-D_QNX_SOURCE`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@
 # *******************************************************************************
 module(
     name = "score_toolchains_qnx",
-    version = "0.0.1",
+    version = "0.0.2",
     compatibility_level = 0,
 )
 

--- a/toolchains/qcc/cc_toolchain_config.bzl
+++ b/toolchains/qcc/cc_toolchain_config.bzl
@@ -180,6 +180,16 @@ def _impl(ctx):
                 flag_groups = [
                     flag_group(
                         flags = [
+                            "-D_QNX_SOURCE",
+                        ],
+                    ),
+                ],
+            ),
+            flag_set(
+                actions = all_cpp_compile_actions,
+                flag_groups = [
+                    flag_group(
+                        flags = [
                             "-std=c++17",
                         ],
                     ),


### PR DESCRIPTION
The `_QNX_SOURCE` define enables QNX-specific extensions and POSIX functions in system headers, but excludes GNU compiler extensions such as those with `-std=gnu++17`.

See https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.prog/topic/devel_ConformingToStandards.html and https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.utilities/topic/q/qcc.html