### PR TITLE
Guard dependency_file flags

### DIFF
--- a/toolchains/qcc/cc_toolchain_config.bzl
+++ b/toolchains/qcc/cc_toolchain_config.bzl
@@ -398,10 +398,13 @@ def _impl(ctx):
                     ACTION_NAMES.cpp_header_parsing,
                     ACTION_NAMES.clif_match,
                 ],
-                flag_groups = [flag_group(flags = [
-                    "-Wc,-MD,%{dependency_file}",
-                    "-Wp,-MD,%{dependency_file}",
-                ])],
+                flag_groups = [flag_group(
+                    flags = [
+                        "-Wc,-MD,%{dependency_file}",
+                        "-Wp,-MD,%{dependency_file}",
+                    ],
+                    expand_if_available = "dependency_file",
+                )],
                 with_features = [
                     with_feature_set(not_features = ["dependency_file_named_implicitly"]),
                 ],


### PR DESCRIPTION
rules_rust dont provide dependency_file

Closes: https://github.com/eclipse-score/toolchains_qnx/issues/22