### PR TITLE
aarch64 QNX toolchain fixes

### DIFF
--- a/toolchains/fs/ifs/ifs.BUILD
+++ b/toolchains/fs/ifs/ifs.BUILD
@@ -21,6 +21,15 @@ qnx_fs_toolchain_config(
     target = "@%{toolchain_sdp}//:target_all",
 )
 
+qnx_fs_toolchain_config(
+    name = "mkifs_toolchain_aarch64",
+    executable = "@%{toolchain_sdp}//:aarch64_mkifs",
+    host_dir = "@%{toolchain_sdp}//:aarch64_host_dir",
+    target_dir = "@%{toolchain_sdp}//:aarch64_target_dir",
+    host = "@%{toolchain_sdp}//:aarch64_host_all",
+    target = "@%{toolchain_sdp}//:aarch64_target_all",
+)
+
 toolchain(
     name = "ifs_x86_64",
     exec_compatible_with = [
@@ -46,7 +55,7 @@ toolchain(
         "@platforms//cpu:aarch64",
         "@platforms//os:qnx",
     ],
-    toolchain = ":mkifs_toolchain",
+    toolchain = ":mkifs_toolchain_aarch64",
     toolchain_type = "@score_toolchains_qnx//toolchains/fs/ifs:toolchain_type",
 )
 

--- a/toolchains/qcc/toolchain.BUILD
+++ b/toolchains/qcc/toolchain.BUILD
@@ -20,6 +20,13 @@ filegroup(
 )
 
 filegroup(
+    name = "aarch64_all_files",
+    srcs = [
+        "@%{toolchain_sdp}//:aarch64_all_files",
+    ],
+)
+
+filegroup(
     name = "empty",
 )
 
@@ -74,13 +81,13 @@ toolchain(
 
 cc_toolchain_config(
     name = "qcc_toolchain_config_aarch64",
-    ar_binary = "@%{toolchain_sdp}//:ar",
-    cc_binary = "@%{toolchain_sdp}//:qcc",
-    cxx_binary = "@%{toolchain_sdp}//:qpp",
-    strip_binary = "@%{toolchain_sdp}//:strip",
-    qnx_host = "@%{toolchain_sdp}//:host_dir",
-    qnx_target = "@%{toolchain_sdp}//:target_dir",
-    cxx_builtin_include_directories = "@%{toolchain_sdp}//:cxx_builtin_include_directories",
+    ar_binary = "@%{toolchain_sdp}//:aarch64_ar",
+    cc_binary = "@%{toolchain_sdp}//:aarch64_qcc",
+    cxx_binary = "@%{toolchain_sdp}//:aarch64_qpp",
+    strip_binary = "@%{toolchain_sdp}//:aarch64_strip",
+    qnx_host = "@%{toolchain_sdp}//:aarch64_host_dir",
+    qnx_target = "@%{toolchain_sdp}//:aarch64_target_dir",
+    cxx_builtin_include_directories = "@%{toolchain_sdp}//:aarch64_cxx_builtin_include_directories",
     # only flags differ
     arch = "aarch64",
     qcc_version = "12.2.0",
@@ -91,14 +98,14 @@ cc_toolchain_config(
 
 cc_toolchain(
     name = "qcc_toolchain",
-    all_files = ":all_files",
-    ar_files = ":all_files",
-    as_files = ":all_files",
-    compiler_files = ":all_files",
+    all_files = ":aarch64_all_files",
+    ar_files = ":aarch64_all_files",
+    as_files = ":aarch64_all_files",
+    compiler_files = ":aarch64_all_files",
     dwp_files = ":empty",
-    linker_files = ":all_files",
+    linker_files = ":aarch64_all_files",
     objcopy_files = ":empty",
-    strip_files = ":all_files",
+    strip_files = ":aarch64_all_files",
     toolchain_config = ":qcc_toolchain_config_aarch64",
 )
 

--- a/toolchains/sdp.BUILD
+++ b/toolchains/sdp.BUILD
@@ -72,3 +72,64 @@ filegroup(
     name = "mkifs",
     srcs = ["host/linux/x86_64/usr/bin/mkifs"],
 )
+
+
+# AARCH64
+filegroup(
+    name = "aarch64_all_files",
+    srcs = glob(["*/**/*"]),
+)
+
+filegroup(
+    name = "aarch64_cxx_builtin_include_directories",
+    srcs = [
+        "host/linux/x86_64/usr/lib/gcc/aarch64-unknown-nto-qnx8.0.0/12.2.0/include",
+        "target/qnx/usr/include",
+        "target/qnx/usr/include/c++/v1",
+    ],
+)
+
+filegroup(
+    name = "aarch64_ar",
+    srcs = ["host/linux/x86_64/usr/bin/aarch64-unknown-nto-qnx8.0.0-ar"],
+)
+
+filegroup(
+    name = "aarch64_qcc",
+    srcs = ["host/linux/x86_64/usr/bin/qcc"],
+)
+
+filegroup(
+    name = "aarch64_qpp",
+    srcs = ["host/linux/x86_64/usr/bin/q++"],
+)
+
+filegroup(
+    name = "aarch64_strip",
+    srcs = ["host/linux/x86_64/usr/bin/aarch64-unknown-nto-qnx8.0.0-strip"],
+)
+
+filegroup(
+    name = "aarch64_host_all",
+    srcs = glob(["host/linux/x86_64/**/*"]),
+)
+
+filegroup(
+    name = "aarch64_host_dir",
+    srcs = ["host/linux/x86_64"],
+)
+
+filegroup(
+    name = "aarch64_target_all",
+    srcs = glob(["target/qnx/**/*"]),
+)
+
+filegroup(
+    name = "aarch64_target_dir",
+    srcs = ["target/qnx"],
+)
+
+filegroup(
+    name = "aarch64_mkifs",
+    srcs = ["host/linux/x86_64/usr/bin/mkifs"],
+)


### PR DESCRIPTION
Add specific SDP build file for aarach64
to correct paths