### PR TITLE
ifs: Support tarballs as input

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@
 # *******************************************************************************
 module(
     name = "score_toolchains_qnx",
-    version = "0.0.3",
+    version = "0.0.4",
     compatibility_level = 0,
 )
 
@@ -20,3 +20,4 @@ bazel_dep(name = "aspect_rules_lint", version = "1.0.3")
 bazel_dep(name = "buildifier_prebuilt", version = "7.3.1")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "score_cr_checker", version = "0.2.2")
+bazel_dep(name = "tar.bzl", version = "0.7.0")

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@score_toolchains_qnx//rules/fs:ifs.bzl", "qnx_ifs")
 
 config_setting(
@@ -46,6 +47,22 @@ cc_binary(
     srcs = ["main.c"],
 )
 
+pkg_tar(
+    name = "main_cpp_as_pkg",
+    srcs = [
+        ":main_cpp",
+    ],
+    package_dir = "/some_directory",
+)
+
+pkg_tar(
+    name = "main_cpp_as_different_pkg",
+    srcs = [
+        ":main_cpp",
+    ],
+    package_dir = "/some_other_directory",
+)
+
 qnx_ifs(
     name = "init",
     # Only include the install tree as inputs on aarch64
@@ -69,6 +86,10 @@ qnx_ifs(
         ":is_qnx_aarch64": ["install"],  # relative to the .build file’s dir
         "//conditions:default": [],
     }),
+    tars = {
+        "EXAMPLE_KEY": ":main_cpp_as_pkg.tar",
+        "ANOTHER_KEY": ":main_cpp_as_different_pkg.tar",
+    },
 )
 
 sh_binary(

--- a/tests/MODULE.bazel
+++ b/tests/MODULE.bazel
@@ -46,3 +46,5 @@ archive_override(
         "https://github.com/qorix-group/custom-qemu/releases/download/1.0.0/custom_qemu.tar.gz",
     ],
 )
+
+bazel_dep(name = "rules_pkg", version = "1.1.0")

--- a/tests/init_x86_64.build
+++ b/tests/init_x86_64.build
@@ -54,3 +54,6 @@ devc-ser8250
 [type=link] ls=toybox
 [type=link] rm=toybox
 
+/some_directory=${EXAMPLE_KEY}
+/another_directory=${ANOTHER_KEY}
+


### PR DESCRIPTION
This enables to package binaries and config files as tarballs and provide this as input for the IFS build.

This way, a user can decide where to unpack certain tarballs in the IFS image.