### PR TITLE
Fix the IFS toolchain used by reference_integration in case of floating

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,7 +12,7 @@
 # *******************************************************************************
 module(
     name = "score_toolchains_qnx",
-    version = "0.0.3",
+    version = "0.0.4",
     compatibility_level = 0,
 )
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ build:x86_64-qnx --platforms=@score_toolchains_qnx//platforms:x86_64-qnx
 build:x86_64-qnx --sandbox_writable_path=/var/tmp
 ```
 
+USER .bazelrc
+In case of QNX floating license setting is necessary you have to define the right value in your user .bazelrc like:
+```
+common --action_env=QNXLM_LICENSE_FILE=<your_license_url>
+```
+
 ```/var/tmp``` needs to be writeable inside of the sandbox because of the license management done by the QNX tools.
 
 ## Where to obtain the QNX 8.0 SDP

--- a/toolchains/fs/toolchain.bzl
+++ b/toolchains/fs/toolchain.bzl
@@ -20,11 +20,14 @@ ToolInfo = provider(
 )
 
 def _impl(ctx):
+    qnxlm_license_file = ctx.configuration.default_shell_env.get("QNXLM_LICENSE_FILE", "")
+
     env = {
         "QNX_HOST": "/proc/self/cwd/" + ctx.file.host_dir.path,
         "QNX_TARGET": "/proc/self/cwd/" + ctx.file.target_dir.path,
         "QNX_CONFIGURATION_EXCLUSIVE": "/var/tmp/.qnx",
         "QNX_SHARED_LICENSE_FILE": "/opt/score_qnx/license/licenses",
+        "QNXLM_LICENSE_FILE": qnxlm_license_file,
         "PATH": "/proc/self/cwd/" + ctx.file.host_dir.path + "/usr/bin",
     }
 


### PR DESCRIPTION
This PR is to add the QNX floating license option handling needed by reference_integration repo in IFS build process.
Related issue: https://github.com/eclipse-score/reference_integration/issues/12
